### PR TITLE
fix: Validation for campervan concession fee

### DIFF
--- a/parkstay/templates/ps/booking/make_booking.html
+++ b/parkstay/templates/ps/booking/make_booking.html
@@ -486,7 +486,7 @@
                                                 <span v-if="pricing.vehicle && !vehicle[2] && (vehicle[0] == 0 || vehicle[0] == 2 || vehicle[0] == 3) " class="vehicle-price">AUD: $0.00</span>
                                             </div>
                                             <div>
-                                                <span v-if="pricing.vehicle && vehicle[0] == 0 && vehicle[2] && vehicle[5]" class="vehicle-price">AUD: ${{ pricing.vehicle_conc }}</span>
+                                                <span v-if="pricing.vehicle && (vehicle[0] == 0 || vehicle[0] == 3 ) && vehicle[2] && vehicle[5]" class="vehicle-price">AUD: ${{ pricing.vehicle_conc }}</span>
                                             </div>
                                             <div>
                                                 <span v-if="pricing.vehicle && vehicle[0] == 0 && vehicle[2] && !vehicle[5]" class="vehicle-price">AUD: ${{ pricing.vehicle }}</span>
@@ -495,7 +495,7 @@
                                                 <span v-if="pricing.vehicle && vehicle[0] == 2 && vehicle[2]" class="vehicle-price">AUD: ${{ pricing.motorcycle }}<span>
                                             </div>
                                             <div>
-                                                <span v-if="pricing.vehicle && vehicle[0] == 3 && vehicle[2]" class="vehicle-price">AUD: ${{ pricing.campervan }}<span>
+                                                <span v-if="pricing.vehicle && vehicle[0] == 3 && vehicle[2] && !vehicle[5]" class="vehicle-price">AUD: ${{ pricing.campervan }}<span>
                                             </div>
                                         </div>
                                       </div>


### PR DESCRIPTION
Concession fees are applied when a Campervan is booked, and it's reflected on the Checkout point

![image](https://github.com/user-attachments/assets/4ca3326e-91d0-44c2-9d04-5030805de172)


![image](https://github.com/user-attachments/assets/3ced0822-a516-4608-ba36-ce2e107c41f3)
