### PR TITLE
Concession fees only apply to Car/Ute and motorcycle

### DIFF
--- a/parkstay/api.py
+++ b/parkstay/api.py
@@ -2465,12 +2465,12 @@ def booking_updates(request, *args, **kwargs):
                  if v[0] == 2:
                      if entry_fee_required:
                          vehicle_entry_fee = entry_fees.motorbike
+                         if concession is True:
+                             vehicle_entry_fee = entry_fees.concession
                      vehicle_type='motorbike'
                  if v[0] == 3:
                      if entry_fee_required:
                          vehicle_entry_fee = entry_fees.campervan
-                         if concession is True:
-                             vehicle_entry_fee = entry_fees.concession
                      vehicle_type='campervan'
                  if v[0] == 4:
                      if entry_fee_required:

--- a/parkstay/templates/ps/booking/make_booking.html
+++ b/parkstay/templates/ps/booking/make_booking.html
@@ -467,7 +467,7 @@
 
                                           <div class="col-md-2">
 						  
-                                            <div class="form-check form-switch" v-if="campers.concession > 0 && (vehicle[0] == 0 || vehicle[0] == 3 ) && vehicle[2] == true" >  
+                                            <div class="form-check form-switch" v-if="campers.concession > 0 && (vehicle[0] == 0 || vehicle[0] == 2 ) && vehicle[2] == true" >  
                              <label class="form-check-label">
 						       <input class="form-check-input" v-bind:name="'form-'+Number(index).toString()+'-concession'" type="checkbox" v-model="vehicle[5]" v-on-click="updateVehiclesFees" checked/> Concession driver</label>
 
@@ -486,16 +486,16 @@
                                                 <span v-if="pricing.vehicle && !vehicle[2] && (vehicle[0] == 0 || vehicle[0] == 2 || vehicle[0] == 3) " class="vehicle-price">AUD: $0.00</span>
                                             </div>
                                             <div>
-                                                <span v-if="pricing.vehicle && (vehicle[0] == 0 || vehicle[0] == 3 ) && vehicle[2] && vehicle[5]" class="vehicle-price">AUD: ${{ pricing.vehicle_conc }}</span>
+                                                <span v-if="pricing.vehicle && (vehicle[0] == 0 || vehicle[0] == 2 ) && vehicle[2] && vehicle[5]" class="vehicle-price">AUD: ${{ pricing.vehicle_conc }}</span>
                                             </div>
                                             <div>
                                                 <span v-if="pricing.vehicle && vehicle[0] == 0 && vehicle[2] && !vehicle[5]" class="vehicle-price">AUD: ${{ pricing.vehicle }}</span>
                                             </div>
                                             <div>
-                                                <span v-if="pricing.vehicle && vehicle[0] == 2 && vehicle[2]" class="vehicle-price">AUD: ${{ pricing.motorcycle }}<span>
+                                                <span v-if="pricing.vehicle && vehicle[0] == 2 && vehicle[2] && !vehicle[5]" class="vehicle-price">AUD: ${{ pricing.motorcycle }}<span>
                                             </div>
                                             <div>
-                                                <span v-if="pricing.vehicle && vehicle[0] == 3 && vehicle[2] && !vehicle[5]" class="vehicle-price">AUD: ${{ pricing.campervan }}<span>
+                                                <span v-if="pricing.vehicle && vehicle[0] == 3 && vehicle[2]" class="vehicle-price">AUD: ${{ pricing.campervan }}<span>
                                             </div>
                                         </div>
                                       </div>


### PR DESCRIPTION
Setting Cars/Utes and motorcycles to be able to use the concession fees. 
 Concession Switch will only be displayed for these vehicle types and the same rule will apply in the update_booking() method
